### PR TITLE
fix(cropper): keep overlays aligned with display bounds

### DIFF
--- a/src/main/windows/cropperWindow.ts
+++ b/src/main/windows/cropperWindow.ts
@@ -1,9 +1,17 @@
 import { BrowserWindow } from "electron";
 import { isDevelopment, pageRoot, preload } from "../static";
 
-export const createWindow = (display: Electron.Display) => {
+/**
+ * Create a hidden cropper window that matches the display's DIP bounds.
+ */
+export const createWindow = (display: Electron.Display): BrowserWindow => {
+  const { x, y, width, height } = display.bounds;
   const win = new BrowserWindow({
     title: "Cropping...",
+    x,
+    y,
+    width,
+    height,
     resizable: false,
     movable: false,
     minimizable: false,
@@ -26,24 +34,17 @@ export const createWindow = (display: Electron.Display) => {
     win.setAlwaysOnTop(true, "screen-saver");
   });
 
+  win.once("ready-to-show", () => {
+    win.show();
+    win.focus();
+  });
+
   if (isDevelopment) {
     win.loadURL(pageRoot + `#/cropper/${display.id}`);
     win.webContents.openDevTools();
   } else {
     win.loadFile(pageRoot, { hash: `/cropper/${display.id}` });
   }
-
-  win.setBounds({
-    x: display.bounds.x,
-    y: display.bounds.y,
-    width: display.bounds.width,
-    height: display.bounds.height,
-  });
-
-  win.webContents.on("did-finish-load", () => {
-    win.show();
-    win.focus();
-  });
 
   return win;
 };

--- a/src/renderer/src/views/Cropper.vue
+++ b/src/renderer/src/views/Cropper.vue
@@ -1,6 +1,11 @@
 <script lang="ts" setup>
-import { computed, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRoute } from "vue-router";
+
+type ViewportSize = {
+  width: number;
+  height: number;
+};
 
 const route = useRoute();
 
@@ -14,24 +19,39 @@ const overlay = ref(
     } | null
   >null
 );
-const svgStyle = computed(() => {
-  return {
-    width: `${window.innerWidth}px`,
-    height: `${window.innerHeight}px`,
-  };
+
+/**
+ * Read the current renderer viewport dimensions in display-independent pixels.
+ */
+const readViewportSize = (): ViewportSize => ({
+  width: window.innerWidth,
+  height: window.innerHeight,
 });
 
+const viewportSize = ref(readViewportSize());
+
+/**
+ * Build an SVG coordinate system that matches the current viewport.
+ */
 const viewBox = computed(() => {
-  // fill display area
-  return `0 0 ${window.innerWidth} ${window.innerHeight}`;
+  const { width, height } = viewportSize.value;
+  return `0 0 ${width} ${height}`;
 });
 
+/**
+ * Build the even-odd path for the dimmed viewport and optional selection.
+ */
 const pathD = computed(() => {
+  const { width, height } = viewportSize.value;
+
   return overlay.value
-    ? `M0,0 v${window.innerHeight} h${window.innerWidth} v${-window.innerHeight} z M${overlay.value.x},${overlay.value.y} h${overlay.value.width} v${overlay.value.height} h${-overlay.value.width} z`
-    : `M0,0 v${window.innerHeight} h${window.innerWidth} v${-window.innerHeight} z`;
+    ? `M0,0 v${height} h${width} v${-height} z M${overlay.value.x},${overlay.value.y} h${overlay.value.width} v${overlay.value.height} h${-overlay.value.width} z`
+    : `M0,0 v${height} h${width} v${-height} z`;
 });
 
+/**
+ * Start a display-local crop selection.
+ */
 const onMouseDown = (event: MouseEvent) => {
   overlay.value = {
     x: event.clientX,
@@ -41,6 +61,9 @@ const onMouseDown = (event: MouseEvent) => {
   };
 };
 
+/**
+ * Resize the active crop selection to the current pointer position.
+ */
 const onMouseMove = (event: MouseEvent) => {
   if (overlay.value) {
     overlay.value.width = event.clientX - overlay.value.x;
@@ -75,11 +98,41 @@ const onMouseUp = () => {
   });
 };
 
-window.addEventListener("keydown", (event) => {
+/**
+ * Quit the application when the user presses Escape.
+ */
+const onKeyDown = (event: KeyboardEvent): void => {
   if (event.key === "Escape") {
     window.ipc.send("exit");
   }
-});
+};
+
+/**
+ * Synchronize reactive dimensions with the renderer viewport.
+ */
+const syncViewportSize = (): void => {
+  viewportSize.value = readViewportSize();
+};
+
+/**
+ * Register window-scoped listeners for this cropper view.
+ */
+const setupWindowListeners = (): void => {
+  syncViewportSize();
+  window.addEventListener("resize", syncViewportSize);
+  window.addEventListener("keydown", onKeyDown);
+};
+
+/**
+ * Remove window-scoped listeners when this cropper view is unmounted.
+ */
+const teardownWindowListeners = (): void => {
+  window.removeEventListener("resize", syncViewportSize);
+  window.removeEventListener("keydown", onKeyDown);
+};
+
+onMounted(setupWindowListeners);
+onUnmounted(teardownWindowListeners);
 </script>
 
 <template>
@@ -89,11 +142,7 @@ window.addEventListener("keydown", (event) => {
     @mousemove="onMouseMove"
     @mouseup="onMouseUp"
   >
-    <svg
-      :style="svgStyle"
-      :view-box="viewBox"
-      xmlns="http://www.w3.org/2000/svg"
-    >
+    <svg class="overlay" :viewBox="viewBox" xmlns="http://www.w3.org/2000/svg">
       <path fill="rgba(0, 0, 0, 0.5)" :d="pathD" fill-rule="evenodd"></path>
     </svg>
   </div>
@@ -101,8 +150,15 @@ window.addEventListener("keydown", (event) => {
 
 <style lang="scss" scoped>
 .cropper {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  cursor: crosshair;
+}
+
+.overlay {
+  display: block;
   width: 100%;
   height: 100%;
-  cursor: crosshair;
 }
 </style>


### PR DESCRIPTION
## Summary

- Create each cropper window with the target display's DIP bounds before loading the renderer
- Show the window on `ready-to-show` instead of resizing it after `did-finish-load`
- Keep the cropper SVG, `viewBox`, and dimming path synchronized with renderer resize events
- Remove window-scoped listeners when the cropper view unmounts

## Root cause

The cropper `BrowserWindow` was initially created at Electron's default size and resized only after page loading had started. The renderer then derived its SVG dimensions from non-reactive `window.innerWidth` and `window.innerHeight` reads, so a resize could leave the overlay at its initial dimensions. The template also emitted `view-box` rather than SVG's case-sensitive `viewBox`.

Together, these timing and renderer-state issues made the black overlay intermittently fail to cover the complete display on macOS.

## Impact

Cropper windows now paint at the correct display bounds from their first frame and continue covering the renderer viewport when display metrics change.

## Validation

- `pnpm test` — 13/13 passed
- `pnpm exec tsc --noEmit -p tsconfig.json` — passed
- `pnpm exec vue-tsc --noEmit -p src/renderer/tsconfig.json` — passed
- `pnpm exec prettier --check src/main/windows/cropperWindow.ts src/renderer/src/views/Cropper.vue` — passed
- `pnpm exec electron-vite build` — passed
- Browser resize regression: 800×600 and 1200×900 SVG bounds, `viewBox`, and path bounds matched the viewport
- Independent UI flow and QA audits — passed

## Stack

- Depends on #72
- Base branch: `codex/fix-capture-scaling`

Fixes #54